### PR TITLE
Fix a incorrecly updated GetCurrencyInfo call in Currencyflow:UpdateLabel

### DIFF
--- a/Broker_Currencyflow.lua
+++ b/Broker_Currencyflow.lua
@@ -825,9 +825,11 @@ function Currencyflow:UpdateLabel()
         else
           color = ""
         end
-        local currencyInfo = C_CurrencyInfo.GetCurrencyInfo(currencyId)
+        local currencyInfo = C_CurrencyInfo.GetCurrencyInfo(segment)
         if currencyInfo ~= nil then
           amount = currencyInfo.quantity
+        else
+          amount = 0
         end
       elseif tracking[segment].type == TYPE_ITEM then amount = GetItemCount(segment,true) or 0 end
       return self:FormatCurrency(amount, (color or "")).." |T"..tracking[segment].icon..":0|t"


### PR DESCRIPTION
Fix this GetCurrencyInfo call to use the `segment` argument instead of a non existent `currencyId` variable.  
https://github.com/wow-addon/Broker_CurrencyFlow/blob/8402664d542c77f732f8653b5685deb3ffe7fc26/Broker_Currencyflow.lua#L828-L831

I tried to match what the call was before here https://github.com/wow-addon/Broker_CurrencyFlow/commit/c81a9f66fa3819b87a0c06baa4ef65b5c45e7d66#diff-c71802c5bcaf8ee4530dbfaf23c60962f154046d7ca73b78344068f1149f0e66L767