### PR TITLE
Fix also alignment of the other (non-gold) currencies (was #21)

### DIFF
--- a/Broker_Currencyflow.lua
+++ b/Broker_Currencyflow.lua
@@ -660,7 +660,7 @@ function Currencyflow:drawTooltip()
 
   for id,currency in pairs(tracking) do
     if self.db.profile["showCurrency"..id] then
-      tooltip:SetCell( lineNum, colNum, "|T"..currency.icon..":16|t", "CENTER" )
+      tooltip:SetCell( lineNum, colNum, "|T"..currency.icon..":16|t", "RIGHT" )
       tooltip:SetCellScript( lineNum, colNum, "OnEnter", function()
         if not CurrencyHeaderTooltip then CurrencyHeaderTooltip = CreateFrame("GameTooltip", "CurrencyHeaderTooltip", UIParent, "GameTooltipTemplate") end
         CurrencyHeaderTooltip:SetOwner(tooltip, "ANCHOR_CURSOR")


### PR DESCRIPTION
You closed issue https://github.com/wow-addon/Broker_CurrencyFlow/issues/21, but in https://github.com/wow-addon/Broker_CurrencyFlow/commit/0d7694e93391347c6063d315556b4acc7865581b you right-aligned only the Gold column headers:

![bad](https://github.com/user-attachments/assets/e3eb1694-d041-4073-9b2e-5836c1d6aefb)

I guess this was an oversight, hence the PR. 

This is what it looks like with also the other currency headers aligned (line 663):

![fixed](https://github.com/user-attachments/assets/189cb98e-18af-4e9f-b016-65e81e201363)
